### PR TITLE
Replaced wired character (c2) with space.

### DIFF
--- a/roles/wordpress/vars/main.yml
+++ b/roles/wordpress/vars/main.yml
@@ -10,7 +10,7 @@ wordpress_varnish_server:
   listen_ssl: [ '443' ]
   ssl: '{{ wordpress_ssl }}'
   pki_crt: '{{ wordpress_nginx_crt }}'
-  pki_key: '{{ wordpress_nginx_key }}'
+  pki_key: '{{ wordpress_nginx_key }}'
   root: False
   index: False
   deny_hidden: False


### PR DESCRIPTION
Can be checked via Vim with `:set list` and `:normal g8`.
