### PR TITLE
Allow to serve WordPress via HTTP and HTTPS and don’t redirect HTTP to HTTPS.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,13 @@ v0.2.0
 - Changed variable from ``wordpress_url`` to
   ``wordpress_domain`` for consistency reasons. [ypid]
 
+- Allow to serve WordPress via HTTP and HTTPS and don’t redirect HTTP to HTTPS.
+  Default is still HTTP only. [ypid]
+
+- Enable SSL/TLS support by default using a self signed CA and host certificate
+  and serve the site via HTTP and HTTPS simultaneity.
+  User/Admins Login is redirected to HTTPS. [ypid]
+
 v0.1.0
 ------
 

--- a/roles/wordpress/defaults/main.yml
+++ b/roles/wordpress/defaults/main.yml
@@ -123,8 +123,18 @@ wordpress_php5_max_children: '10'
 
 # .. envvar:: wordpress_ssl
 #
-# Whether our WordPress site is using SSL or not
-wordpress_ssl: False
+# Whether our WordPress site is using SSL or not.
+wordpress_ssl: True
+
+# .. envvar:: wordpress_http_and_https
+#
+# If False, the HTTP site will not redirect to HTTPS.
+# So this allows you to serve your blog via HTTP by default and optionally
+# provide and HTTPS version for users who really want it.
+# This option is only active when :ref:`wordpress_ssl` is True.
+# Default is False.
+wordpress_http_and_https: False
+
 
 # .. envvar:: wordpress_ssl_crt
 # .. envvar:: wordpress_ssl_key

--- a/roles/wordpress/vars/main.yml
+++ b/roles/wordpress/vars/main.yml
@@ -23,7 +23,7 @@ wordpress_varnish_server:
     '/': |
       {% if (wordpress_ssl|d() | bool) and not (wordpress_redirect_to_ssl|d(True) | bool) %}
       if ($scheme = 'http') {
-        rewrite ^/wp-(admin|login.php) https://$host$uri permanent;
+        rewrite /wp-(admin|login.php) https://$host$uri permanent;
       }
       {% endif %}
       proxy_set_header X-Real-IP $remote_addr;
@@ -82,7 +82,9 @@ wordpress_backend_server:
       text/x-cross-domain-policy
       text/xml;
 
-    rewrite ^/wp-admin$ $scheme://$host$uri/ permanent;
+    # rewrite ^/wp-admin$ $scheme://$host$uri/ permanent;
+    # A start of string match would conflict with wordpress_multisite_subdomains==False.
+    rewrite /wp-admin$ $scheme://$host$uri/ permanent;
     {% if wordpress_multisite and not wordpress_multisite_subdomains %}
 
     if (!-e $request_filename) {

--- a/roles/wordpress/vars/main.yml
+++ b/roles/wordpress/vars/main.yml
@@ -11,6 +11,7 @@ wordpress_varnish_server:
   ssl: '{{ wordpress_ssl }}'
   pki_crt: '{{ wordpress_nginx_crt }}'
   pki_key: '{{ wordpress_nginx_key }}'
+  redirect_to_ssl: '{{ wordpress_http_and_https }}'
   root: False
   index: False
   deny_hidden: False
@@ -20,6 +21,11 @@ wordpress_varnish_server:
 
   location:
     '/': |
+      {% if (wordpress_ssl|d() | bool) and not (wordpress_redirect_to_ssl|d(True) | bool) %}
+      if ($scheme = 'http') {
+        rewrite ^/wp-(admin|login.php) https://$host$uri permanent;
+      }
+      {% endif %}
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto {% if wordpress_ssl is defined and wordpress_ssl %}https{% else %}http{% endif %};
@@ -76,7 +82,7 @@ wordpress_backend_server:
       text/x-cross-domain-policy
       text/xml;
 
-    rewrite /wp-admin$ $scheme://$host$uri/ permanent;
+    rewrite ^/wp-admin$ $scheme://$host$uri/ permanent;
     {% if wordpress_multisite and not wordpress_multisite_subdomains %}
 
     if (!-e $request_filename) {


### PR DESCRIPTION
This enables TLS support by default using a self-signed certificate and redirects admin logins to it.

Related to:
- https://github.com/debops/ansible-nginx/pull/76
- https://github.com/carlalexander/debops-wordpress/issues/1

When applying this patch note that it will conflict with #36 so you have to resolve this as shown in #29.
