### PR TITLE
Update debops commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ wordpress.example.com
 Once that's done, you just need to run two command lines. Each of them can take several minutes to run.
 
 ```bash
-$ debops
-$ debops wordpress
+$ debops -u root
+$ debops wordpress -u root
 ```
 
 ## Acknowledgements


### PR DESCRIPTION
Add `-u root` to README debops commands, as per the instructions on the [Configuring your server](https://github.com/carlalexander/debops-wordpress/wiki/Configuring-your-server) wiki page.
