### PR TITLE
Hostname is not listed under debops_all_hosts

### DIFF
--- a/inventory/hosts
+++ b/inventory/hosts
@@ -8,8 +8,8 @@
 # View the list here:
 # https://github.com/debops/debops-playbooks/blob/master/playbooks/common.yml
 
-#<hostname>
 [debops_all_hosts]
+#<hostname>
 
 [wordpress]
 #<hostname>


### PR DESCRIPTION
On the latest version of debops it fails.

all_servers needs to be changed to debops_all_hosts in the Wiki
https://github.com/carlalexander/debops-wordpress/wiki/Configuring-your-server
