### PR TITLE
Fix IPv6

### DIFF
--- a/roles/wordpress/vars/main.yml
+++ b/roles/wordpress/vars/main.yml
@@ -229,8 +229,8 @@ wordpress_server_varnish:
   filename: 'varnish.{{ wordpress_domain }}'
   name: '{{ wordpress_nginx_server_name }}'
   root: False
-  listen: [ '80' ]
-  listen_ssl: [ '443' ]
+  listen: [ '[::]:80' ]
+  listen_ssl: [ '[::]:443' ]
   ssl: '{{ wordpress_ssl }}'
   acme: "{{ wordpress_ssl_provider == 'letsencrypt' }}"
   csp: '{{ wordpress_nginx_csp }}'


### PR DESCRIPTION
When specifying only a port number the server only listens on IPv4. To make it listen on IPv6 the IPv6 wildcard address must be specified (which was the default, so the "listen" and "listen-ssl" lines may as well be removed completely, but I left them in for clarity.
