### PR TITLE
Update to redesigned Content Security Policy support of debops.nginx

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,12 @@ v0.4.0
 - Added ``varnish__privileged_group`` variable to give access to varnish to a
   system group. [carlalexander]
 
+- Update DebOps for WordPress to the redesigned Content Security Policy support of debops.nginx_.
+  ``wordpress__nginx__csp`` has been renamed to ``wordpress__nginx__csp_enabled`` and
+  ``wordpress__nginx__csp_policy`` has been renamed to ``wordpress__nginx__csp``.
+  ``wordpress__nginx__csp_report`` has been dropped. You can use
+  ``nginx__http_csp_append`` to set a custom ``report-uri`` for all policies. [ypid_]
+
 
 v0.3.1
 ------
@@ -195,4 +201,3 @@ v0.1.0
 *Released: 2015-10-11*
 
 - First release, add CHANGES.rst [carlalexander]
-

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ v0.4.0
   ``wordpress__nginx__csp_report`` has been dropped. You can use
   ``nginx__http_csp_append`` to set a custom ``report-uri`` for all policies. [ypid_]
 
+- Update role dependencies of the wordpress role to work with debops.nginx v0.2.0 and above. [ypid_]
+
 
 v0.3.1
 ------

--- a/roles/wordpress/defaults/main.yml
+++ b/roles/wordpress/defaults/main.yml
@@ -328,20 +328,14 @@ wordpress__nginx__location_allow: []
 
 # .. envvar:: wordpress__nginx__csp
 #
-# Whether the WordPress vhost will use the Content-Security-Policy header or not.
-wordpress__nginx__csp: False
-
-# .. envvar:: wordpress__nginx__csp_policy
-#
 # Determines the Content-Security-Policy header configured in the WordPress vhost.
 # By default, blocks all non-https content.
-wordpress__nginx__csp_policy: "default-src https:; script-src https: 'unsafe-eval' 'unsafe-inline'; style-src https: 'unsafe-inline'"
+wordpress__nginx__csp: "default-src https:; script-src https: 'unsafe-eval' 'unsafe-inline'; style-src https: 'unsafe-inline'"
 
-# .. envvar:: wordpress__nginx__csp_report
+# .. envvar:: wordpress__nginx__csp_enabled
 #
-# Whether the WordPress vhost will use the Content-Security-Policy-Report-Only
-# header or not. Overrides the ``wordpress__nginx_csp`` option.
-wordpress__nginx__csp_report: False
+# Whether the WordPress vhost will use the Content-Security-Policy header or not.
+wordpress__nginx__csp_enabled: False
 
 # .. envvar:: wordpress__nginx__listen
 #

--- a/roles/wordpress/meta/main.yml
+++ b/roles/wordpress/meta/main.yml
@@ -14,6 +14,16 @@ dependencies:
     secret_directories:
         - '{{ pki_env_secret_directories }}'
 
+  - role: debops.apt_preferences
+    tags: [ 'role::apt_preferences' ]
+    apt_preferences__dependent_list:
+      - '{{ nginx__apt_preferences__dependent_list }}'
+
+  - role: debops.ferm
+    tags: [ 'role::ferm' ]
+    ferm__dependent_rules:
+      - '{{ nginx__ferm__dependent_rules }}'
+
   - role: debops.users
     tags: [ 'depend::users', 'depend::users:wordpress', 'depend-of::wordpress', 'type::dependency:hard' ]
     users__accounts: '{{ wordpress__users__accounts }}'

--- a/roles/wordpress/vars/main.yml
+++ b/roles/wordpress/vars/main.yml
@@ -227,10 +227,9 @@ wordpress__nginx__server_varnish:
   redirect_from: '{{ wordpress__nginx__redirect_from }}'
   redirect_code: '301'
   ssl: '{{ wordpress__ssl }}'
-  acme: "{{ wordpress__ssl_provider == 'letsencrypt' }}"
+  acme: '{{ wordpress__ssl_provider == "letsencrypt" }}'
   csp: '{{ wordpress__nginx__csp }}'
-  csp_report: '{{ wordpress__nginx__csp_report }}'
-  csp_policy: '{{ wordpress__nginx__csp_policy }}'
+  csp_enabled: '{{ wordpress__nginx__csp_enabled|bool }}'
   ocsp_verify: False
   deny_hidden: False
   favicon: False


### PR DESCRIPTION
@carlalexander Can you merge this on 2017-04-15 so that it works seamlessly with the redesigned interface? Your feedback is very much welcome on the matter even after the Apache changes have already been merged.

Depends on: https://github.com/debops/ansible-nginx/pull/156